### PR TITLE
Stopped `undefined` reviver return value from deleting undefined valu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,6 @@
-### 4.2.5
+### 4.2.1-4.2.6
 
-* Fixed reviver bug that prevented revival of type containers. 
-
-### 4.2.4
-
-* Fixed a reviver bug with quoted property names.
-
-### 4.2.3
-
-* Fixed a reviver bug with non-primitive arguments of function types.
-
-### 4.2.2
-
-* Fixed a couple of bugs related to performing deletions of array/object elements via replacer or reviver functions.
-
-### 4.2.1
-
-* Documentation-only update, clarifying replacer and reviver functions.
+* Fixed assorted replacer/reviver bugs.
 
 ### 4.2.0
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2,7 +2,7 @@ const util = require('./util');
 const big = require('./bignumber-util');
 const optionsMgr = require('./options-manager');
 const { isBigNumber } = require('./bignumber-util');
-const { ValueSourceWrapper } = require('./util');
+const { ValueSourceWrapper, unwrap } = require('./util');
 
 const QUOTE_NONE = 0;
 const QUOTE_SINGLE = 1;
@@ -1205,9 +1205,10 @@ module.exports = function parse(text, reviver, newOptions) {
       const keys = Object.keys(value).reverse();
 
       for (const key of keys) {
+        const original = unwrap(value[key]);
         const replacement = internalize(value, key, reviver);
 
-        if (replacement === undefined || replacement === util.DELETE) {
+        if ((replacement === undefined && original !== undefined) || replacement === util.DELETE) {
           if (!Array.isArray(value) || key < value.length - 1) {
             delete value[key];
           }
@@ -1294,7 +1295,7 @@ module.exports = function parse(text, reviver, newOptions) {
 
     if (reviver && parseState !== 'beforePropertyName') {
       token.offset = savedLastPos;
-      token.source = source.slice(savedLastPos, pos);
+      token.source = source.slice(savedLastPos, pos).trim();
       token.value = new ValueSourceWrapper(value, token.source);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "json-z",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "json-z",
-      "version": "4.2.5",
+      "version": "4.2.6",
       "license": "MIT",
       "dependencies": {
         "minimist": "1.2.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-z",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "description": "JSON for everyone.",
   "main": "lib/index.min.js",
   "types": "lib/index.d.ts",

--- a/test/parse.spec.mjs
+++ b/test/parse.spec.mjs
@@ -569,15 +569,15 @@ it('parse(text, reviver)', () => {
   );
 
   expect(
-    JSONZ.parse('{a:1,b:2}', (k, v) => (k === 'a') ? JSONZ.DELETE : v)).to.deep.equal(
+    JSONZ.parse('{a:1,b:2,c:undefined}', (k, v) => (k && k !== 'b') ? JSONZ.DELETE : v)).to.deep.equal(
     { b: 2 },
     'JSONZ.DELETE deletes property values'
   );
 
   expect(
-    JSONZ.parse('{a:1,b:2}', (k, v) => (k === 'a') ? undefined : v)).to.deep.equal(
-    { b: 2 },
-    '`undefined` deletes property values'
+    JSONZ.parse('{a:1,b:2,c:undefined}', (k, v) => (k && k !== 'b') ? undefined : v)).to.deep.equal(
+    { b: 2, c: undefined },
+    '`undefined` deletes property values (but not already undefined values)'
   );
 
   expect(
@@ -667,6 +667,12 @@ it('parse(text, reviver) special cases', () => {
     JSONZ.stringify(JSONZ.parse('{a:56.78m}', (k, v) => typeof v === 'number' ? 88 : v))).to.equal(
     '{a:56.78m}',
     'should not modify BigDecimal values'
+  );
+
+  expect(
+    JSONZ.stringify(JSONZ.parse('[  4,5   ,   6  ,  7]', (k, v, context) => context.source || v))).to.equal(
+    "['4','5','6','7']",
+    'no white space included in source'
   );
 
   expect(


### PR DESCRIPTION
…es. Trimmed whitespace from context.source.